### PR TITLE
GitHub update check run calls are batched so they do not exceed annotations max size.

### DIFF
--- a/lib/github_check_run_service.rb
+++ b/lib/github_check_run_service.rb
@@ -2,6 +2,7 @@
 
 class GithubCheckRunService
   CHECK_NAME = 'Brakeman'
+  MAX_ANNOTATIONS_SIZE = 50
 
   def initialize(report, github_data, report_adapter)
     @report = report
@@ -19,13 +20,21 @@ class GithubCheckRunService
     @annotations = @report_adapter.annotations(@report)
     @conclusion = @report_adapter.conslusion(@report)
 
-    @client.patch(
-      "#{endpoint_url}/#{id}",
-      update_check_payload
-    )
+    result = {}
+    @annotations.each_slice(MAX_ANNOTATIONS_SIZE) do |annotations|
+      result.merge(client_patch(id, annotations))
+    end
+    result
   end
 
   private
+
+  def client_patch(id, annotations)
+    @client.patch(
+      "#{endpoint_url}/#{id}",
+      update_check_payload(annotations)
+    )
+  end
 
   def endpoint_url
     "/repos/#{@github_data[:owner]}/#{@github_data[:repo]}/check-runs"
@@ -40,7 +49,7 @@ class GithubCheckRunService
     }
   end
 
-  def update_check_payload
+  def update_check_payload(annotations)
     {
       name: CHECK_NAME,
       head_sha: @github_data[:sha],
@@ -50,7 +59,7 @@ class GithubCheckRunService
       output: {
         title: CHECK_NAME,
         summary: @summary,
-        annotations: @annotations
+        annotations: annotations
       }
     }
   end

--- a/lib/github_check_run_service.rb
+++ b/lib/github_check_run_service.rb
@@ -20,6 +20,9 @@ class GithubCheckRunService
     @annotations = @report_adapter.annotations(@report)
     @conclusion = @report_adapter.conslusion(@report)
 
+    pp '$' * 20
+    pp '%' * 20
+
     result = {}
     @annotations.each_slice(MAX_ANNOTATIONS_SIZE) do |annotations|
       result.merge(client_patch(id, annotations))

--- a/spec/github_check_run_service_spec.rb
+++ b/spec/github_check_run_service_spec.rb
@@ -19,14 +19,14 @@ describe GithubCheckRunService do
   end
 
   context 'annotation limit set' do
-    it 'it updates the check run multiple times' do
-    stub_request(:any, 'https://api.github.com/repos/owner/repository_name/check-runs')
-      .to_return(status: 200, body: '{"id": "id"}')
+    it 'updates the check run multiple times' do
+      stub_request(:any, 'https://api.github.com/repos/owner/repository_name/check-runs')
+        .to_return(status: 200, body: '{"id": "id"}')
 
-    stub_const("GithubCheckRunService::MAX_ANNOTATIONS_SIZE", 2)
-    allow(service).to receive(:client_patch).and_return({})
-    expect(service).to receive(:client_patch).twice
-    service.run
+      stub_const("GithubCheckRunService::MAX_ANNOTATIONS_SIZE", 2)
+      allow(service).to receive(:client_patch).and_return({})
+      expect(service).to receive(:client_patch).twice
+      service.run
     end
   end
 end

--- a/spec/github_check_run_service_spec.rb
+++ b/spec/github_check_run_service_spec.rb
@@ -17,4 +17,16 @@ describe GithubCheckRunService do
     output = service.run
     expect(output).to be_a(Hash)
   end
+
+  context 'annotation limit set' do
+    it 'it updates the check run multiple times' do
+    stub_request(:any, 'https://api.github.com/repos/owner/repository_name/check-runs')
+      .to_return(status: 200, body: '{"id": "id"}')
+
+    stub_const("GithubCheckRunService::MAX_ANNOTATIONS_SIZE", 2)
+    allow(service).to receive(:client_patch).and_return({})
+    expect(service).to receive(:client_patch).twice
+    service.run
+    end
+  end
 end


### PR DESCRIPTION
Updated such that calls to update check runs in GitHub are batched so that the annotations per call does not exceed 50, which is the max annotations per request.
 @novu/platinum

# Type of PR (feature, enhancement, bug fix, etc.)
Enhancement

## Description
When generating reports, updating check runs fails because the maximum annotation size of 50 is exceeded.
Please include a summary of the change and which issue is fixed.

Fixes # (issue)

## Why should this be added
The annotation size when updating a check run should not cause the check process to fail.
Explain value.
CI should not report failure when all checks have passed but fails due to max annotation size being exceeded when generating report.
## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] Actions are passing
