### PR TITLE
NOVU-33945 | Convert to GitHub Actions

### DIFF
--- a/spec/github_check_run_service_spec.rb
+++ b/spec/github_check_run_service_spec.rb
@@ -17,4 +17,16 @@ describe GithubCheckRunService do
     output = service.run
     expect(output).to be_a(Hash)
   end
+
+  context 'annotation limit set' do
+    it 'updates the check run multiple times' do
+      stub_request(:any, 'https://api.github.com/repos/owner/repository_name/check-runs')
+        .to_return(status: 200, body: '{"id": "id"}')
+
+      stub_const("GithubCheckRunService::MAX_ANNOTATIONS_SIZE", 2)
+      allow(service).to receive(:client_patch).and_return({})
+      expect(service).to receive(:client_patch).twice
+      service.run
+    end
+  end
 end


### PR DESCRIPTION
Updated such that calls to update check runs in GitHub are batched so that the annotations per call does not exceed 50, which is the max annotations per request.
@novu/platinum

# Type of PR (feature, enhancement, bug fix, etc.)
Enhancement
## Description
When generating reports, updating check runs fails because the maximum annotation size of 50 is exceeded.
Please include a summary of the change and which issue is fixed.
Please include a summary of the change and which issue is fixed.

Fixes # (issue)

## Why should this be added
The annotation size when updating a check run should not cause the check process to fail.
Explain value.
CI should not report failure when all checks have passed but fails due to max annotation size being exceeded when generating report.
Explain value.
Process will not fail when annotations exceed 50.
## Checklist

- [x ] My code follows the style guidelines of this project
- [x] Actions are passing
