### PR TITLE
Can specify a project path

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,16 @@ Brakeman is a static analysis tool which checks Ruby on Rails applications for s
     REPORT_PATH: tmp/brakeman.json
 ```
 
+### Custom path
+
+```yml
+- name: Brakeman
+  uses: devmasx/brakeman-linter-action@v1.0.0
+  env:
+    GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+    PROJECT_PATH: my_rails_app
+```
+
 ### Example Workflow
 
 ```

--- a/lib/index.rb
+++ b/lib/index.rb
@@ -11,6 +11,8 @@ def read_json(path)
   JSON.parse(File.read(path))
 end
 
+project_path = ENV['PROJECT_PATH'].nil? ? ENV['GITHUB_WORKSPACE'] : "#{ENV['GITHUB_WORKSPACE']}/#{ENV['PROJECT_PATH']}"
+
 @event_json = read_json(ENV['GITHUB_EVENT_PATH']) if ENV['GITHUB_EVENT_PATH']
 @github_data = {
   sha: ENV['GITHUB_SHA'],
@@ -23,7 +25,7 @@ end
   if ENV['REPORT_PATH']
     read_json(ENV['REPORT_PATH'])
   else
-    Dir.chdir(ENV['GITHUB_WORKSPACE']) { JSON.parse(`brakeman -f json`) }
+    Dir.chdir(project_path) { JSON.parse(`brakeman -f json`) }
   end
 
 GithubCheckRunService.new(@report, @github_data, ReportAdapter).run


### PR DESCRIPTION
Some repository does not have their ruby/rails app at the root. This PR adds the ability to specify a path to run brakeman.
Fixes # (issue)